### PR TITLE
Use `vim.filetype.add()` to set the filetype for neoconf.json

### DIFF
--- a/lua/neoconf/commands.lua
+++ b/lua/neoconf/commands.lua
@@ -60,21 +60,17 @@ function M.setup()
   end
 
   if Config.options.filetype_jsonc then
-    vim.api.nvim_create_autocmd("BufRead", {
-      pattern = Util.file_patterns({ autocmd = true }),
-      group = group,
-      callback = function(event)
-        vim.api.nvim_buf_set_option(event.buf, "filetype", "jsonc")
-      end,
-    })
-    -- local jsonc = {}
-    -- for _, p in ipairs(Util.file_patterns()) do
-    --   jsonc[p] = "jsonc"
-    -- end
-    --
-    -- vim.filetype.add({
-    --   pattern = jsonc,
-    -- })
+    if vim.g.do_legacy_filetype then
+      vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
+        pattern = Util.file_patterns({ autocmd = true }),
+        group = group,
+        callback = function(event)
+          vim.api.nvim_buf_set_option(event.buf, "filetype", "jsonc")
+        end,
+      })
+    else
+      vim.filetype.add(Util.filetype_patterns())
+    end
   end
 end
 

--- a/lua/neoconf/util.lua
+++ b/lua/neoconf/util.lua
@@ -67,6 +67,8 @@ function M.on_config(opts)
   end)
 end
 
+---@param opts? { local: boolean, global: boolean, autocmd: boolean }
+---@return string[]
 function M.file_patterns(opts)
   opts = M.merge({ ["local"] = true, ["global"] = true }, opts)
   local ret = {}
@@ -92,6 +94,25 @@ function M.file_patterns(opts)
   end
 
   return ret
+end
+
+---@return { pattern: table<string, string>, filename: table<string, string> }
+function M.filetype_patterns()
+  local pattern = {}
+  local filename = {}
+
+  for _, p in ipairs(M.file_patterns({ autocmd = true })) do
+    if p:find("/") ~= nil then
+      pattern[".*/" .. p:gsub("%.", "%."):gsub("%*", ".*")] = "jsonc"
+    else
+      filename[p] = "jsonc"
+    end
+  end
+
+  return {
+    pattern = pattern,
+    filename = filename,
+  }
 end
 
 function M.path(str)


### PR DESCRIPTION
Fixes #23
Closes #24 

In addition to the issue outlined in #23, there is a similar problem when issuing `:e` on an already open configuration file when using `neoconf` and `nvim-lspconfig`. To reproduce the issue, follow these steps:

1. Edit neovim config to call `vim.lsp.set_log_level('debug')`
2. Open an existing neoconf config file from the command line (ex. `nvim .neoconf.json`)
3. Inspect the LSP log and search for `textDocument/didOpen`. Look for `languageId` and note that it is set to `"jsonc"`.
4. With the neoconf config file open, run `:e`.
5. Inspect the LSP log and search for `textDocument/didOpen`. Look for `languageId` and note that it is set to `"json"`.

In the case of `nvim .neoconf.json`, the LSP has not been initialized until after the autocommand in `neoconf/commands.lua` has run, so when it gets the filetype, it sends the one neoconf sets. In the case of `:e`, the autocommand in `$VIMRUNTIME/filetype.lua` runs and sets the filetype, which causes the `FileType` autocommand in `lspconfig/configs.lua` to run, which issues a `textDocument/didOpen` with `languageId` set to the filetype determined in `$VIMRUNTIME/filetype.lua`. Then the autocommand in `neoconf/commands.lua` runs, sets the filetype, which causes the `FileType` autocommand in `lspconfig/configs.lua` to run, and `nvim-lspconfig` does not issue another `textDocument/didOpen`.

This PR hooks into neovim's filetype detection via `vim.filetype.add()` (when it's available) to ensure that the filetype is set in a consistent manner so the LSP mechanisms in neovim correctly send the filetype to the LSP client.