### PR TITLE
feat: allow root_dir conflict resolution in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ require("lspconfig").lua_ls.setup(...)
   -- set the filetype to jsonc for settings files, so you can use comments
   -- make sure you have the jsonc treesitter parser installed!
   filetype_jsonc = true,
+  --- Returns which root_dir to pick when two are available
+  ---@param a? string First potential root_dir
+  ---@param b? string Second potential root_dir
+  ---@return string?
+  root_dir_picker = function(a, b)
+    if a and b then
+      -- return longest
+      return (#a > #b) and a or b
+    end
+
+    return a or b
+  end,
   plugins = {
     -- configures lsp clients with settings in the following order:
     -- - lua settings passed in lspconfig setup

--- a/doc/neoconf.nvim.txt
+++ b/doc/neoconf.nvim.txt
@@ -92,6 +92,18 @@ CONFIGURATION                        *neoconf.nvim-neoconf.nvim-configuration*
       -- set the filetype to jsonc for settings files, so you can use comments
       -- make sure you have the jsonc treesitter parser installed!
       filetype_jsonc = true,
+      --- Returns which root_dir to pick when two are available
+      ---@param a? string First potential root_dir
+      ---@param b? string Second potential root_dir
+      ---@return string?
+      root_dir_picker = function(a, b)
+	if a and b then
+	  -- return longest
+	  return (#a > #b) and a or b
+	end
+
+	return a or b
+      end,
       plugins = {
         -- configures lsp clients with settings in the following order:
         -- - lua settings passed in lspconfig setup

--- a/lua/neoconf/config.lua
+++ b/lua/neoconf/config.lua
@@ -17,6 +17,18 @@ M.defaults = {
   -- set the filetype to jsonc for settings files, so you can use comments
   -- make sure you have the jsonc treesitter parser installed!
   filetype_jsonc = true,
+  --- Returns which root_dir to pick when two are available
+  ---@param a? string First potential root_dir
+  ---@param b? string Second potential root_dir
+  ---@return string?
+  root_dir_picker = function(a, b)
+    if a and b then
+      -- return longest
+      return (#a > #b) and a or b
+    end
+
+    return a or b
+  end,
   plugins = {
     -- configures lsp clients with settings in the following order:
     -- - lua settings passed in lspconfig setup

--- a/lua/neoconf/util.lua
+++ b/lua/neoconf/util.lua
@@ -57,11 +57,7 @@ function M.on_config(opts)
         end
         local a = opts.root_dir(...)
 
-        if a and b then
-          -- return longest
-          return #a > #b and a or b
-        end
-        return a or b
+        return Config.options.root_dir_picker(a, b)
       end
     end
   end)


### PR DESCRIPTION
Hello,

First of all thank you for the plugin which is working wonderfully well and solves an immense pain of working with nvim in a vs code world.

While working in a Rust monorepo, my workspace root_dir is set to `${REPO_ROOT}/.cargo/workspace`, while the root dir for some crates is `${REPO_ROOT}/path/to/crate`.

If the `path/to/crate` is shorter than `.cargo/workspace`, neoconf resolves the root dir as `.cargo/workspace` since it is longer. This is not a desired behavior on my end, since the monorepo is very large and rust-analyzer commes with insane behavior on startup for large code base.

This PR aims to make the conflict resolution performed in `neoconf/util.lua`.

Don't hesitate to tear the code a new one, this is my first lua PR, and I find the code in this plugin quite complex :sweat_smile: 

Cheers