### PR TITLE
feat(readme): add `lazy.nvim` installation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@
 
 Install the plugin with your preferred package manager:
 
+### [lazy.nvim](https://github.com/folke/lazy.nvim)
+
+```lua
+{ "folke/neoconf.nvim", opts = {} }
+```
+
 ### [packer](https://github.com/wbthomason/packer.nvim)
 
 ```lua

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Install the plugin with your preferred package manager:
 ### [lazy.nvim](https://github.com/folke/lazy.nvim)
 
 ```lua
-{ "folke/neoconf.nvim", opts = {} }
+{ "folke/neoconf.nvim" }
 ```
 
 ### [packer](https://github.com/wbthomason/packer.nvim)


### PR DESCRIPTION
thank you very much for your work!

that's a very minor change, but I believe it makes sense to add `lazy.nvim` installation example to the readme.

thanks!