### PR TITLE
fix: don't error if lspconfig is not installed

### DIFF
--- a/lua/neoconf/health.lua
+++ b/lua/neoconf/health.lua
@@ -44,9 +44,9 @@ function M.check()
     warn("**neodev.nvim** is not installed. You won't get any proper completion for your Neovim config.")
   end
 
-  local _, lspconfig = pcall(require, "lspconfig.util")
+  local has_lspconfig, lspconfig = pcall(require, "lspconfig.util")
 
-  if lspconfig then
+  if has_lspconfig then
     ok("**lspconfig** is installed")
     local available = lspconfig.available_servers()
     if vim.tbl_contains(available, "jsonls") then
@@ -60,7 +60,7 @@ function M.check()
       warn("**lspconfig lua_ls** is not installed? You won't get any auto completion in your lua settings files")
     end
   else
-    error("**lspconfig** not installed?")
+    warn("**lspconfig** not installed?")
   end
 end
 


### PR DESCRIPTION
I don't use lspconfig, but I currently use neoconf to tell neodev which plugins to load include in the lua-language-server's `workspace.library` (with `lspconfig = false`).

Since i removed lspconfig from my plugins, neoconf errors because it expects it to be installed.
This PR adds some checks to prevent that from happening.

I'm not sure if neoconf is useful without lspconfig (neodev is still adding the neovim lua API, but it doesn't seem to pick up the plugin lists in neoconf.json anymore).
