### PR TITLE
fix(build): fix schema generation issues

### DIFF
--- a/lua/neoconf/build/annotations.lua
+++ b/lua/neoconf/build/annotations.lua
@@ -1,5 +1,4 @@
 local util = require("neoconf.util")
-local Schema = require("neoconf.schema")
 
 local M = {}
 
@@ -168,7 +167,7 @@ local lspconfig
 
 ]]
 
-  local index = vim.tbl_keys(require("neoconf.build.schemas").index())
+  local index = vim.tbl_keys(require("neoconf.build.schemas").get_schemas())
   table.sort(index)
 
   for _, name in ipairs(index) do
@@ -201,7 +200,7 @@ end
 
 function M.build()
   M.lines = { "---@meta\n" }
-  local index = vim.tbl_keys(require("neoconf.build.schemas").index())
+  local index = vim.tbl_keys(require("neoconf.build.schemas").get_schemas())
   table.sort(index)
   for _, name in ipairs(index) do
     local ok, err = pcall(M.build_annotations, name)

--- a/lua/neoconf/build/init.lua
+++ b/lua/neoconf/build/init.lua
@@ -1,10 +1,9 @@
 local util = require("neoconf.util")
-local Schema = require("neoconf.schema")
 
 local M = {}
 
 function M.docs()
-  local schemas = require("neoconf.build.schemas").index()
+  local schemas = require("neoconf.build.schemas").get_schemas()
   local keys = vim.tbl_keys(schemas)
   table.sort(keys)
   local lines = {}

--- a/lua/neoconf/build/schemas.lua
+++ b/lua/neoconf/build/schemas.lua
@@ -1,7 +1,71 @@
 local Util = require("neoconf.util")
-local Schema = require("neoconf.schema")
 
 local M = {}
+
+-- modified from https://gist.githubusercontent.com/williamboman/a01c3ce1884d4b57cc93422e7eae7702/raw/lsp-packages.json
+M.index = {
+  als = "https://raw.githubusercontent.com/AdaCore/ada_language_server/master/integration/vscode/ada/package.json",
+  astro = "https://raw.githubusercontent.com/withastro/language-tools/main/packages/vscode/package.json",
+  awkls = "https://raw.githubusercontent.com/Beaglefoot/awk-language-server/master/client/package.json",
+  bashls = "https://raw.githubusercontent.com/bash-lsp/bash-language-server/master/vscode-client/package.json",
+  clangd = "https://raw.githubusercontent.com/clangd/vscode-clangd/master/package.json",
+  cssls = "https://raw.githubusercontent.com/microsoft/vscode/main/extensions/css-language-features/package.json",
+  dartls = "https://raw.githubusercontent.com/Dart-Code/Dart-Code/master/package.json",
+  denols = "https://raw.githubusercontent.com/denoland/vscode_deno/main/package.json",
+  elixirls = "https://raw.githubusercontent.com/elixir-lsp/vscode-elixir-ls/master/package.json",
+  elmls = "https://raw.githubusercontent.com/elm-tooling/elm-language-client-vscode/master/package.json",
+  eslint = "https://raw.githubusercontent.com/microsoft/vscode-eslint/main/package.json",
+  flow = "https://raw.githubusercontent.com/flowtype/flow-for-vscode/master/package.json",
+  fsautocomplete = "https://raw.githubusercontent.com/ionide/ionide-vscode-fsharp/main/release/package.json",
+  grammarly = "https://raw.githubusercontent.com/znck/grammarly/main/extension/package.json",
+  haxe_language_server = "https://raw.githubusercontent.com/vshaxe/vshaxe/master/package.json",
+  hhvm = "https://raw.githubusercontent.com/slackhq/vscode-hack/master/package.json",
+  hie = "https://raw.githubusercontent.com/alanz/vscode-hie-server/master/package.json",
+  html = "https://raw.githubusercontent.com/microsoft/vscode/main/extensions/html-language-features/package.json",
+  intelephense = "https://raw.githubusercontent.com/bmewburn/vscode-intelephense/master/package.json",
+  java_language_server = "https://raw.githubusercontent.com/georgewfraser/java-language-server/master/package.json",
+  jdtls = "https://raw.githubusercontent.com/redhat-developer/vscode-java/master/package.json",
+  jsonls = "https://raw.githubusercontent.com/microsoft/vscode/master/extensions/json-language-features/package.json",
+  julials = "https://raw.githubusercontent.com/julia-vscode/julia-vscode/master/package.json",
+  kotlin_language_server = "https://raw.githubusercontent.com/fwcd/vscode-kotlin/master/package.json",
+  ltex = "https://raw.githubusercontent.com/valentjn/vscode-ltex/develop/package.json",
+  lua_ls = "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/package.json",
+  luau_lsp = "https://raw.githubusercontent.com/JohnnyMorganz/luau-lsp/main/editors/code/package.json",
+  -- nickel_ls = "https://raw.githubusercontent.com/tweag/nickel/master/lsp/client-extension/package.json",
+  omnisharp = "https://raw.githubusercontent.com/OmniSharp/omnisharp-vscode/master/package.json",
+  perlls = "https://raw.githubusercontent.com/richterger/Perl-LanguageServer/master/clients/vscode/perl/package.json",
+  perlnavigator = "https://raw.githubusercontent.com/bscan/PerlNavigator/main/package.json",
+  perlpls = "https://raw.githubusercontent.com/FractalBoy/perl-language-server/master/client/package.json",
+  powershell_es = "https://raw.githubusercontent.com/PowerShell/vscode-powershell/main/package.json",
+  psalm = "https://raw.githubusercontent.com/psalm/psalm-vscode-plugin/master/package.json",
+  puppet = "https://raw.githubusercontent.com/puppetlabs/puppet-vscode/main/package.json",
+  purescriptls = "https://raw.githubusercontent.com/nwolverson/vscode-ide-purescript/master/package.json",
+  pylsp = "https://raw.githubusercontent.com/python-lsp/python-lsp-server/develop/pylsp/config/schema.json",
+  pyright = "https://raw.githubusercontent.com/microsoft/pyright/master/packages/vscode-pyright/package.json",
+  r_language_server = "https://raw.githubusercontent.com/REditorSupport/vscode-r-lsp/master/package.json",
+  rescriptls = "https://raw.githubusercontent.com/rescript-lang/rescript-vscode/master/package.json",
+  rls = "https://raw.githubusercontent.com/rust-lang/vscode-rust/master/package.json",
+  rome = "https://raw.githubusercontent.com/rome/tools/main/editors/vscode/package.json",
+  rust_analyzer = "https://raw.githubusercontent.com/rust-analyzer/rust-analyzer/master/editors/code/package.json",
+  solargraph = "https://raw.githubusercontent.com/castwide/vscode-solargraph/master/package.json",
+  solidity_ls = "https://raw.githubusercontent.com/juanfranblanco/vscode-solidity/master/package.json",
+  sorbet = "https://raw.githubusercontent.com/sorbet/sorbet/master/vscode_extension/package.json",
+  sourcekit = "https://raw.githubusercontent.com/swift-server/vscode-swift/main/package.json",
+  spectral = "https://raw.githubusercontent.com/stoplightio/vscode-spectral/master/package.json",
+  stylelint_lsp = "https://raw.githubusercontent.com/bmatcuk/coc-stylelintplus/master/package.json",
+  svelte = "https://raw.githubusercontent.com/sveltejs/language-tools/master/packages/svelte-vscode/package.json",
+  svlangserver = "https://raw.githubusercontent.com/eirikpre/VSCode-SystemVerilog/master/package.json",
+  tailwindcss = "https://raw.githubusercontent.com/tailwindlabs/tailwindcss-intellisense/master/packages/vscode-tailwindcss/package.json",
+  terraformls = "https://raw.githubusercontent.com/hashicorp/vscode-terraform/master/package.json",
+  tsserver = "https://raw.githubusercontent.com/microsoft/vscode/main/extensions/typescript-language-features/package.json",
+  volar = "https://raw.githubusercontent.com/vuejs/language-tools/master/extensions/vscode/package.json",
+  vtsls = "https://raw.githubusercontent.com/yioneko/vtsls/main/packages/service/configuration.schema.json",
+  vuels = "https://raw.githubusercontent.com/vuejs/vetur/master/package.json",
+  wgls_analyzer = "https://raw.githubusercontent.com/wgsl-analyzer/wgsl-analyzer/main/editors/code/package.json",
+  yamlls = "https://raw.githubusercontent.com/redhat-developer/vscode-yaml/master/package.json",
+  zeta_note = "https://raw.githubusercontent.com/artempyanykh/zeta-note-vscode/main/package.json",
+  zls = "https://raw.githubusercontent.com/zigtools/zls-vscode/master/package.json",
+}
 
 ---@class LspSchema
 ---@field package_url string url of the package.json of the LSP server
@@ -31,24 +95,17 @@ M.overrides = {
 }
 
 ---@return table<string, LspSchema>
-function M.index()
+function M.get_schemas()
   ---@type table<string, LspSchema>
   local ret = {}
-  local packages = vim.json.decode(Util.read_file(Util.path("schemas/index.json")))
 
-  packages["volar"] = "https://raw.githubusercontent.com/vuejs/language-tools/master/extensions/vscode/package.json"
-  packages["lua_ls"] = "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/package.json"
-  packages["sumneko_lua"] = nil
-  packages["nickel_ls"] = nil
-
-  for server, package_json in pairs(packages) do
-    ret[server] = { package_url = package_json }
+  for server, package_json in pairs(M.index) do
+    ret[server] = {
+      package_url = package_json,
+      settings_file = Util.path("schemas/" .. server .. ".json"),
+    }
   end
   ret = vim.tbl_deep_extend("force", ret, M.overrides)
-
-  for name, schema in pairs(ret) do
-    schema.settings_file = Util.path("schemas/" .. name .. ".json")
-  end
 
   return ret
 end
@@ -91,15 +148,19 @@ function M.translate(props, nls_url)
 end
 
 ---@param schema LspSchema
-function M.get_schema(schema)
+function M.fetch_schema(schema)
   local json = vim.json.decode(Util.fetch(schema.package_url)) or {}
   local config = json.contributes and json.contributes.configuration or json.properties and json
 
-  local properties = {}
+  local properties = vim.empty_dict()
 
   if Util.islist(config) then
     for _, c in pairs(config) do
-      vim.list_extend(properties, c.properties)
+      if c.properties then
+        for k, v in pairs(c.properties) do
+          properties[k] = v
+        end
+      end
     end
   elseif config.properties then
     properties = config.properties
@@ -125,22 +186,16 @@ function M.clean()
   end
 end
 
-function M.update_index()
-  local url = "https://gist.githubusercontent.com/williamboman/a01c3ce1884d4b57cc93422e7eae7702/raw/lsp-packages.json"
-  local index = Util.fetch(url)
-  Util.write_file("schemas/index.json", index)
-end
-
 function M.update_schemas()
-  local index = require("neoconf.build.schemas").index()
-  local names = vim.tbl_keys(index)
+  local schemas = M.get_schemas()
+  local names = vim.tbl_keys(schemas)
   table.sort(names)
   for _, name in ipairs(names) do
-    s = index[name]
+    local s = schemas[name]
     print(("Generating schema for %s"):format(name))
 
     if not Util.exists(s.settings_file) then
-      local ok, schema = pcall(M.get_schema, s)
+      local ok, schema = pcall(M.fetch_schema, s)
       if ok then
         Util.write_file(s.settings_file, Util.json_format(schema))
       end
@@ -150,7 +205,6 @@ end
 
 function M.build()
   M.clean()
-  M.update_index()
   M.update_schemas()
 end
 

--- a/lua/neoconf/plugins/lspconfig.lua
+++ b/lua/neoconf/plugins/lspconfig.lua
@@ -10,7 +10,7 @@ function M.on_schema(schema)
     description = "lsp server settings for lspconfig",
   })
 
-  for name, s in pairs(require("neoconf.build.schemas").index()) do
+  for name, s in pairs(require("neoconf.build.schemas").get_schemas()) do
     if Config.options.plugins.jsonls.configured_servers_only == false or Util.has_lspconfig(name) then
       schema:set("lspconfig." .. name, {
         anyOf = {


### PR DESCRIPTION
This fixes a few issues relating to the CI json schema generation.

- befcc1f452e2226d329b67b0510bd5f2e4a75591 fixes #60, and also fixes several other servers that previously had an empty `properties` in the schema. This happened because `c.properties` is a table, which means `vim.list_extend` doesn't do anything. `properties` should also always be an object and not an array, so `vim.empty_dict()` is now being used to prevent outputting `[]` when `properties` is empty.
- 84e19f41b4c0ad6865fdc61f62bae5cff496b71f embeds `index.json` rather than downloading it every time. As mentioned in #54, the gist is no longer maintained, so there's no reason to download it anymore. In the future this should probably be [sourced from elsewhere](https://gist.github.com/williamboman/a01c3ce1884d4b57cc93422e7eae7702?permalink_comment_id=4689512).
- 2a911fd425dabc54847d61c387fabb4cd572907e fixes the URL for Volar.
- 6dfd503dc5a09a040dab00c2922d4d4e0f9374b5 is just me running the build step locally. If I shouldn't have done this I'm happy to revert it.

Fixes #52
Fixes #60 