### PR TITLE
fix(schemas): `tsserver` renamed to `ts_ls`

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ You can additionally use the exported types in other places.
     clangd = {},
     cssls = {},
     dockerls = {},
-    tsserver = {},
+    ts_ls = {},
     svelte = {},
     eslint = {},
     html = {},
@@ -271,7 +271,7 @@ local my_settings = Neoconf.get("neodev", defaults)
 - [x] [svlangserver](https://github.com/eirikpre/VSCode-SystemVerilog/tree/master/package.json)
 - [x] [tailwindcss](https://github.com/tailwindlabs/tailwindcss-intellisense/tree/master/packages/vscode-tailwindcss/package.json)
 - [x] [terraformls](https://github.com/hashicorp/vscode-terraform/tree/master/package.json)
-- [x] [tsserver](https://github.com/microsoft/vscode/tree/main/extensions/typescript-language-features/package.json)
+- [x] [ts_ls](https://github.com/microsoft/vscode/tree/main/extensions/typescript-language-features/package.json)
 - [x] [volar](https://github.com/vuejs/language-tools/tree/master/extensions/vscode/package.json)
 - [x] [vtsls](https://github.com/yioneko/vtsls/tree/main/packages/service/configuration.schema.json)
 - [x] [vuels](https://github.com/vuejs/vetur/tree/master/package.json)

--- a/lua/neoconf/build/schemas.lua
+++ b/lua/neoconf/build/schemas.lua
@@ -58,7 +58,7 @@ M.index = {
   svlangserver = "https://raw.githubusercontent.com/eirikpre/VSCode-SystemVerilog/master/package.json",
   tailwindcss = "https://raw.githubusercontent.com/tailwindlabs/tailwindcss-intellisense/master/packages/vscode-tailwindcss/package.json",
   terraformls = "https://raw.githubusercontent.com/hashicorp/vscode-terraform/master/package.json",
-  tsserver = "https://raw.githubusercontent.com/microsoft/vscode/main/extensions/typescript-language-features/package.json",
+  ts_ls = "https://raw.githubusercontent.com/microsoft/vscode/main/extensions/typescript-language-features/package.json",
   volar = "https://raw.githubusercontent.com/vuejs/language-tools/master/extensions/vscode/package.json",
   vtsls = "https://raw.githubusercontent.com/yioneko/vtsls/main/packages/service/configuration.schema.json",
   vuels = "https://raw.githubusercontent.com/vuejs/vetur/master/package.json",
@@ -81,7 +81,7 @@ M.overrides = {
   jsonls = {
     translate = true,
   },
-  tsserver = {
+  ts_ls = {
     translate = true,
   },
   ltex = {


### PR DESCRIPTION
## Description

`tsserver` was recently renamed to `ts_ls` in `nvim-lspconfig`. This resolves that renaming (https://github.com/neovim/nvim-lspconfig/pull/3232)
