### PR TITLE
fix(lspconfig): add hook before and not after

### DIFF
--- a/lua/neoconf/util.lua
+++ b/lua/neoconf/util.lua
@@ -39,7 +39,7 @@ end
 ---@param opts { on_config: fun(config, root_dir:string, original_config), root_dir: fun(), name: string }
 function M.on_config(opts)
   local lsputil = require("lspconfig.util")
-  local hook = lsputil.add_hook_after
+  local hook = lsputil.add_hook_before
 
   lsputil.on_setup = hook(lsputil.on_setup, function(initial_config)
     if opts.on_config then


### PR DESCRIPTION
## Description
A common use of `on_new_config` is to construct the `cmd` for starting language servers based on the configuration. These language servers require that the settings are finalized before it is run. It looks like previous commits did use `add_hook_before` for the `lspconfig` integration but it got moved to being `add_hook_after` when centralizing it with the `lua_ls` and `jsonls` plugin integrations. We should revert this back to `add_hook_before` so that the existing `on_new_config` functions continue working.

