### PR TITLE
fix(lspconfig): use `_available_servers` in  health.lua

### DIFF
--- a/lua/neoconf/health.lua
+++ b/lua/neoconf/health.lua
@@ -68,7 +68,7 @@ function M.check_setup()
   end
   local lsputil = package.loaded["lspconfig.util"]
   if lsputil then
-    if #lsputil.available_servers() == 0 then
+    if #lsputil._available_servers() == 0 then
       return true
     else
       util.error(


### PR DESCRIPTION
according to https://github.com/neovim/nvim-lspconfig/commit/e118ce58dab72c17216292eef7df4cee3cf60885

## Description

<!-- Describe the big picture of your changes to communicate to the maintainers
  why we should accept this pull request. -->
fixed _available_servers is nil bug.

## Related Issue(s)
https://github.com/folke/neoconf.nvim/issues/104
<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

