### PR TITLE
fix(util): update deprecated methods

### DIFF
--- a/lua/neoconf/util.lua
+++ b/lua/neoconf/util.lua
@@ -29,7 +29,7 @@ function M.root_pattern(...)
 end
 
 function M.find_git_ancestor(...)
-  return require("lspconfig.util").find_git_ancestor(...)
+  return vim.fs.dirname(vim.fs.find(".git", { path = startpath, upward = true })[1])
 end
 
 function M.has_lspconfig(server)

--- a/lua/neoconf/util.lua
+++ b/lua/neoconf/util.lua
@@ -33,7 +33,7 @@ function M.find_git_ancestor(...)
 end
 
 function M.has_lspconfig(server)
-  return vim.tbl_contains(require("lspconfig.util").available_servers(), server)
+  return vim.tbl_contains(require("lspconfig.util")._available_servers(), server)
 end
 
 ---@param opts { on_config: fun(config, root_dir:string, original_config), root_dir: fun(), name: string }


### PR DESCRIPTION
## Description

After updating lspconfig, there is an error when I tried to open `neoconf.json`.

The reason is that `lspconfig.util.available_servers` has been renamed to `lspconfig.util._available_servers`. ([link](https://github.com/neovim/nvim-lspconfig/commit/e118ce58dab72c17216292eef7df4cee3cf60885))

I fixed the issue and also update the deprecated code which is also come from lspconfig.util ([details](https://github.com/neovim/nvim-lspconfig/blob/0e234f4cad56dd77a2c59de5de5a859e05fd66b3/lua/lspconfig/util.lua#L359-L362))

<details>
<summary>error detail</summary>

```
  Error  22:01:18 notify.error settings.nvim Failed to run client.before_init for settings/plugins/jsonls
....local/share/nvim/lazy/neoconf.nvim/lua/neoconf/util.lua:36: attempt to call field 'available_servers' (a nil value)

stack traceback:
	...nvim/lazy/neoconf.nvim/lua/neoconf/plugins/lspconfig.lua:14: in function <...nvim/lazy/neoconf.nvim/lua/neoconf/plugins/lspconfig.lua:8>
	...hare/nvim/lazy/neoconf.nvim/lua/neoconf/plugins/init.lua:14: in function 'fire'
	...hare/nvim/lazy/neoconf.nvim/lua/neoconf/plugins/init.lua:20: in function 'fire'
	...ocal/share/nvim/lazy/neoconf.nvim/lua/neoconf/schema.lua:45: in function 'get'
	...re/nvim/lazy/neoconf.nvim/lua/neoconf/plugins/jsonls.lua:22: in function 'on_config'
	....local/share/nvim/lazy/neoconf.nvim/lua/neoconf/util.lua:49: in function <....local/share/nvim/lazy/neoconf.nvim/lua/neoconf/util.lua:48>
	[C]: in function 'func'
	...al/share/nvim/lazy/nvim-lspconfig/lua/lspconfig/util.lua:53: in function <...al/share/nvim/lazy/nvim-lspconfig/lua/lspconfig/util.lua:51>
	[C]: in function 'pcall'
	...share/nvim/lazy/nvim-lspconfig/lua/lspconfig/configs.lua:217: in function 'make_config'
	...share/nvim/lazy/nvim-lspconfig/lua/lspconfig/manager.lua:160: in function 'add'
	...share/nvim/lazy/nvim-lspconfig/lua/lspconfig/manager.lua:220: in function <...share/nvim/lazy/nvim-lspconfig/lua/lspconfig/manager.lua:207>
	[C]: in function 'pcall'
	...l/share/nvim/lazy/nvim-lspconfig/lua/lspconfig/async.lua:5: in function <...l/share/nvim/lazy/nvim-lspconfig/lua/lspconfig/async.lua:4>
 ```

</details>

## Related Issue(s)

## Screenshots

![image](https://github.com/user-attachments/assets/956a59ff-1767-456a-a0bb-6ccf41d8a4bc)

