### PR TITLE
fix(lspconfig): revert `_available_servers`

### DIFF
--- a/lua/neoconf/health.lua
+++ b/lua/neoconf/health.lua
@@ -68,7 +68,7 @@ function M.check_setup()
   end
   local lsputil = package.loaded["lspconfig.util"]
   if lsputil then
-    if #lsputil._available_servers() == 0 then
+    if #lsputil.available_servers() == 0 then
       return true
     else
       util.error(

--- a/lua/neoconf/util.lua
+++ b/lua/neoconf/util.lua
@@ -33,7 +33,7 @@ function M.find_git_ancestor(...)
 end
 
 function M.has_lspconfig(server)
-  return vim.tbl_contains(require("lspconfig.util")._available_servers(), server)
+  return vim.tbl_contains(require("lspconfig.util").available_servers(), server)
 end
 
 ---@param opts { on_config: fun(config, root_dir:string, original_config), root_dir: fun(), name: string }


### PR DESCRIPTION
## Description

Reverts #105.

[neovim/nvim-lspconfig - PR #3589](https://github.com/neovim/nvim-lspconfig/pull/3589) reverts `_available_servers` back to `available_servers`.

## Related Issue(s)

Fixes #107.

## Screenshots

NA

