### PR TITLE
fix(util): update options of nvim_set_option_value

### DIFF
--- a/lua/neoconf/util.lua
+++ b/lua/neoconf/util.lua
@@ -300,8 +300,8 @@ function M.notify(msg, level)
         scope = "local",
       })
       local buf = vim.api.nvim_win_get_buf(win)
-      vim.api.nvim_set_option_value("filetype", "markdown", { buf = buf, scope = "local" })
-      vim.api.nvim_set_option_value("spell", false, { buf = buf, scope = "local" })
+      vim.api.nvim_set_option_value("filetype", "markdown", { buf = buf })
+      vim.api.nvim_set_option_value("spell", false, { win = win, scope = "local" })
     end,
   })
 end


### PR DESCRIPTION
## Description
After I updated the Neovim to 0.10.4, the error message regard to the nvim_set_option_value shows after updating the LSP settings. Following are the errors:
1. The 'buf' cannot be used with 'scope'.
2. The 'spell' becomes window local option instead of buffer local option.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable. -->

